### PR TITLE
ゲーム結果の表示（イシュー #7）

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,35 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* カスタムアニメーション */
+@keyframes fadeIn {
+  0% { opacity: 0; transform: scale(0.95); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+.animate-fadeIn {
+  animation: fadeIn 0.3s ease-out forwards;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.animate-pulse {
+  animation: pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+/* トランジション効果 */
+.transition-all {
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-transform {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}

--- a/src/components/Game/GameBoard.tsx
+++ b/src/components/Game/GameBoard.tsx
@@ -3,6 +3,8 @@ import { useGameContext } from '@/contexts/GameContext';
 import { Difficulty, GameStatus } from '@/types';
 import Board from './Board';
 import GameControls from '../GameControls';
+import GameResult from './GameResult';
+import MineReveal from './MineReveal';
 
 /**
  * ゲームボードコンポーネント
@@ -13,9 +15,13 @@ const GameBoard: React.FC = () => {
     board,
     status,
     difficulty,
+    timer,
+    minesCount,
+    flagsCount,
     revealCell,
     toggleFlag,
-    chordCell
+    chordCell,
+    resetGame
   } = useGameContext();
 
   // 難易度に対応するボードサイズ情報を取得
@@ -55,6 +61,16 @@ const GameBoard: React.FC = () => {
     }
   }, []);
 
+  // ゲームがクリアしたかどうかの判定
+  const isGameFinished = useMemo(() => {
+    return status === GameStatus.WON || status === GameStatus.LOST;
+  }, [status]);
+
+  // リスタート処理
+  const handleRestart = useCallback(() => {
+    resetGame();
+  }, [resetGame]);
+
   return (
     <div className="flex flex-col items-center p-4 max-w-4xl mx-auto">
       {/* ゲーム情報エリア */}
@@ -74,7 +90,7 @@ const GameBoard: React.FC = () => {
 
       {/* ゲームボード - ラッパーを追加してレスポンシブデザインを強化 */}
       <div className="w-full overflow-auto flex justify-center">
-        <div className="min-w-min">
+        <div className="min-w-min relative">
           <Board
             board={board}
             difficulty={difficulty}
@@ -82,8 +98,27 @@ const GameBoard: React.FC = () => {
             onFlagCell={toggleFlag}
             onChordCell={chordCell}
           />
+          
+          {/* ゲーム終了時に地雷表示を追加 */}
+          {isGameFinished && (
+            <MineReveal 
+              board={board}
+              isGameLost={status === GameStatus.LOST}
+              difficulty={difficulty}
+            />
+          )}
         </div>
       </div>
+
+      {/* ゲーム結果モーダル */}
+      <GameResult
+        status={status}
+        difficulty={difficulty}
+        timer={timer}
+        flagsCount={flagsCount}
+        minesCount={minesCount + flagsCount}
+        onRestart={handleRestart}
+      />
 
       {/* 操作説明 */}
       <div className="mt-6 p-3 bg-gray-100 dark:bg-gray-800 rounded text-sm text-gray-700 dark:text-gray-300 w-full max-w-md">

--- a/src/components/Game/GameResult.tsx
+++ b/src/components/Game/GameResult.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useState } from 'react';
+import { Difficulty, GameStatus } from '@/types';
+
+interface GameResultProps {
+  status: GameStatus;
+  difficulty: Difficulty;
+  timer: number;
+  flagsCount: number;
+  minesCount: number;
+  onRestart: () => void;
+}
+
+/**
+ * ゲーム結果を表示するモーダルコンポーネント
+ * 勝利または敗北時にゲーム結果と統計情報を表示
+ */
+const GameResult: React.FC<GameResultProps> = ({
+  status,
+  difficulty,
+  timer,
+  flagsCount,
+  minesCount,
+  onRestart
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [animateClass, setAnimateClass] = useState('');
+
+  // ゲーム状態に応じてモーダルの表示/非表示を制御
+  useEffect(() => {
+    if (status === GameStatus.WON || status === GameStatus.LOST) {
+      setIsVisible(true);
+      // アニメーションを遅延させて適用（モーダルが表示された後）
+      setTimeout(() => {
+        setAnimateClass('animate-fadeIn');
+      }, 100);
+    } else {
+      setIsVisible(false);
+      setAnimateClass('');
+    }
+  }, [status]);
+
+  // 表示しない場合はnullを返す
+  if (!isVisible) {
+    return null;
+  }
+
+  // 難易度に応じたラベルを取得
+  const getDifficultyLabel = (diff: Difficulty): string => {
+    switch (diff) {
+      case Difficulty.BEGINNER:
+        return '初級';
+      case Difficulty.INTERMEDIATE:
+        return '中級';
+      case Difficulty.EXPERT:
+        return '上級';
+      case Difficulty.CUSTOM:
+        return 'カスタム';
+      default:
+        return '不明';
+    }
+  };
+
+  // 勝利時のメッセージを生成
+  const getWinMessage = (): string => {
+    if (timer < 60) {
+      return 'すごい！短時間でクリアしました！';
+    } else if (timer < 180) {
+      return 'お見事！上手くプレイされました！';
+    } else {
+      return 'おめでとうございます！クリア達成！';
+    }
+  };
+
+  // 敗北時のメッセージを生成
+  const getLoseMessage = (): string => {
+    if (timer < 10) {
+      return '運が悪かったですね...もう一度チャレンジしてみましょう！';
+    } else if (flagsCount > minesCount / 2) {
+      return '惜しい！もう少しで勝てたかもしれません。';
+    } else {
+      return '地雷を踏んでしまいました...もう一度挑戦してみましょう！';
+    }
+  };
+
+  // タイマーの表示形式を整える
+  const formatTime = (seconds: number): string => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className={`bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-md w-full mx-4 p-6 ${animateClass}`}>
+        {/* ヘッダー部分 */}
+        <div className="text-center mb-6">
+          {status === GameStatus.WON ? (
+            <>
+              <h2 className="text-2xl font-bold text-green-600 dark:text-green-400 mb-2">
+                勝利！
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                {getWinMessage()}
+              </p>
+            </>
+          ) : (
+            <>
+              <h2 className="text-2xl font-bold text-red-600 dark:text-red-400 mb-2">
+                ゲームオーバー
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                {getLoseMessage()}
+              </p>
+            </>
+          )}
+        </div>
+
+        {/* 統計情報 */}
+        <div className="bg-gray-100 dark:bg-gray-700 rounded-lg p-4 mb-6">
+          <h3 className="text-lg font-semibold mb-3 text-gray-800 dark:text-gray-200">
+            ゲーム統計
+          </h3>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="text-gray-700 dark:text-gray-300">難易度:</div>
+            <div className="font-medium text-right text-gray-800 dark:text-gray-200">
+              {getDifficultyLabel(difficulty)}
+            </div>
+            
+            <div className="text-gray-700 dark:text-gray-300">プレイ時間:</div>
+            <div className="font-medium text-right text-gray-800 dark:text-gray-200">
+              {formatTime(timer)}
+            </div>
+            
+            <div className="text-gray-700 dark:text-gray-300">使用フラグ数:</div>
+            <div className="font-medium text-right text-gray-800 dark:text-gray-200">
+              {flagsCount} / {minesCount}
+            </div>
+          </div>
+        </div>
+
+        {/* アクションボタン */}
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <button
+            onClick={onRestart}
+            className="py-2 px-6 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg 
+                      transition-colors duration-200 flex-1 sm:flex-initial"
+            aria-label="新しいゲームを開始"
+          >
+            新しいゲーム
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GameResult;

--- a/src/components/Game/MineReveal.tsx
+++ b/src/components/Game/MineReveal.tsx
@@ -1,0 +1,117 @@
+import React, { useMemo } from 'react';
+import { Difficulty, SquareNode } from '@/types';
+
+interface MineRevealProps {
+  board: SquareNode[][];
+  isGameLost: boolean;
+  difficulty?: Difficulty; // 難易度に基づいてセルサイズを調整
+}
+
+/**
+ * ゲーム終了時に全ての地雷位置を表示するコンポーネント
+ * 勝利時：全ての地雷にフラグが立てられた状態を表示
+ * 敗北時：すべての地雷位置と誤ったフラグを表示
+ */
+const MineReveal: React.FC<MineRevealProps> = ({
+  board,
+  isGameLost,
+  difficulty = Difficulty.BEGINNER
+}) => {
+  // 難易度に基づいてセルサイズを計算
+  const cellSize = useMemo(() => {
+    switch (difficulty) {
+      case Difficulty.BEGINNER:
+        return 40;
+      case Difficulty.INTERMEDIATE:
+        return 32;
+      case Difficulty.EXPERT:
+        return 28;
+      case Difficulty.CUSTOM:
+      default:
+        return board[0] && board[0].length > 20 ? 28 : 
+               board[0] && board[0].length > 16 ? 32 : 40;
+    }
+  }, [difficulty, board]);
+
+  // モバイル用にサイズを調整
+  const mobileAdjustment = useMemo(() => {
+    return typeof window !== 'undefined' && window.innerWidth < 768 ? 0.8 : 1;
+  }, []);
+
+  // 最終的なセルサイズを計算
+  const finalCellSize = cellSize * mobileAdjustment;
+  
+  // 内部のインジケーターサイズを計算
+  const indicatorSize = Math.max(finalCellSize * 0.6, 16);
+
+  return (
+    <div className="absolute inset-0 pointer-events-none">
+      {board.map((row, y) => (
+        <div key={`mine-reveal-row-${y}`} className="flex">
+          {row.map((cell, x) => {
+            // 地雷のみを表示（既に開かれた地雷は除く）
+            if (cell.isMine && !cell.isRevealed) {
+              return (
+                <div 
+                  key={`mine-reveal-${x}-${y}`}
+                  className="absolute"
+                  style={{
+                    top: `${y * finalCellSize}px`,
+                    left: `${x * finalCellSize}px`,
+                    width: `${finalCellSize}px`,
+                    height: `${finalCellSize}px`,
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    zIndex: 10,
+                    transition: 'opacity 0.3s ease-in-out',
+                    opacity: 1
+                  }}
+                >
+                  <div className={`
+                    rounded-full animate-pulse
+                    ${isGameLost ? 'bg-red-500' : 'bg-green-500'} 
+                  `} 
+                  style={{ width: `${indicatorSize}px`, height: `${indicatorSize}px` }}
+                  />
+                </div>
+              );
+            }
+            
+            // 誤ったフラグを表示（敗北時のみ）
+            if (isGameLost && cell.isFlagged && !cell.isMine) {
+              return (
+                <div 
+                  key={`wrong-flag-${x}-${y}`}
+                  className="absolute"
+                  style={{
+                    top: `${y * finalCellSize}px`,
+                    left: `${x * finalCellSize}px`,
+                    width: `${finalCellSize}px`,
+                    height: `${finalCellSize}px`,
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    zIndex: 10
+                  }}
+                >
+                  <div style={{ width: `${indicatorSize}px`, height: `${indicatorSize}px` }}
+                       className="flex items-center justify-center">
+                    <div className="relative flex items-center justify-center">
+                      <div className="text-red-600 font-bold" 
+                           style={{ fontSize: `${indicatorSize * 1.2}px` }}>✗</div>
+                    </div>
+                  </div>
+                </div>
+              );
+            }
+            
+            return null;
+          })}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MineReveal;


### PR DESCRIPTION
## 概要
このPRでは、マインスイーパーのゲーム結果表示機能を実装しました。イシュー #7 に対応する実装です。

## 実装内容
- **GameResult.tsx**: 
  - ゲームの勝敗結果を表示するモーダルコンポーネント
  - プレイ時間や難易度などの統計情報表示
  - 勝利・敗北状況に応じたメッセージ表示
  - 再チャレンジボタンの実装

- **MineReveal.tsx**:
  - ゲーム終了時に全地雷位置を視覚的に表示
  - 勝利時は緑色、敗北時は赤色で地雷位置をハイライト
  - 誤ったフラグ位置の表示（敗北時）
  - 難易度に応じた動的なセルサイズ調整

- **GameBoard.tsx**:
  - GameResultとMineRevealコンポーネントの統合
  - ゲーム状態に応じた表示制御

- **globals.css**:
  - フェードインやパルスアニメーションの追加
  - 視覚効果を向上させるトランジション

## 技術的詳細
- React上で状態に応じたUI表示の条件分岐
- TailwindCSSを使用したスタイリングとアニメーション
- GameContextとの連携によるゲーム状態管理
- レスポンシブデザイン対応

## 動作確認項目
- 勝利時に緑色のハイライトとお祝いメッセージを表示
- 敗北時に赤色のハイライトと励ましメッセージを表示
- モーダルから再チャレンジでゲームが正しくリセットされる
- 異なる難易度での動作確認
- モバイルデバイスでの表示確認

Closes #7